### PR TITLE
Add Vercel deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,1 @@
+from local_multi_agents_app import application as app

--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -1,4 +1,8 @@
-import os, json, urllib.request, time, random
+import os
+import json
+import urllib.request
+import time
+import random
 from flask import Flask, request, jsonify, render_template
 from flask_socketio import SocketIO, emit
 import threading
@@ -12,7 +16,12 @@ OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.1")
 TEMPERATURE = float(os.getenv("TEMPERATURE", "0.7"))
 CONVERSATION_PACE_SECONDS = 7 # AIの応答間隔（秒）
 
-app = Flask(__name__, template_folder="templates", static_folder="static")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+app = Flask(
+    __name__,
+    template_folder=os.path.join(BASE_DIR, "templates"),
+    static_folder=os.path.join(BASE_DIR, "static"),
+)
 app.config['SECRET_KEY'] = 'secret!'
 socketio = SocketIO(app, async_mode='threading')
 
@@ -133,3 +142,6 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", "5000"))
     print(f"Starting server on http://localhost:{port}")
     socketio.run(app, host="0.0.0.0", port=port, debug=True, allow_unsafe_werkzeug=True)
+
+# Expose a WSGI-compatible application for platforms like Vercel
+application = socketio.WSGIApp(socketio, app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+flask-socketio

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/socket.io/(.*)", "dest": "api/index.py" },
+    { "src": "/(.*)", "dest": "api/index.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Flask app for Vercel by exposing a WSGI application
- add serverless entry point and Vercel routing
- document dependencies and ignore Python caches

## Testing
- `python -m py_compile local_multi_agents_app.py api/index.py`
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc05b3e4548328a65063bdcde8fe7b