### PR TITLE
feat: add mention and append reply logic

### DIFF
--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -69,15 +69,20 @@ def conversation_loop():
                 speaker = msg.get("name", "ユーザー")
                 transcript += f"{speaker}: {msg['content']}\n"
             
-            system_prompt = agent_to_speak["system"]
+            system_prompt = (
+                agent_to_speak["system"]
+                + " 会話の流れを大切にし、他の参加者に話すときは@名前でメンションしてください。"
+                + " 自分の直前の発言に追記したい場合は新しいメッセージではなく前の発言に追加するつもりで考えてください。"
+            )
             response_length_instruction = agent_to_speak.get('response_length', '3文以内')
 
             user_prompt = (
                 f"これはあなたと他の登場人物との会話の台本です。\n"
-                f"--- 台本 --- \n{transcript}" 
+                f"--- 台本 --- \n{transcript}"
                 f"--- 台本ここまで --- \n\n"
                 f"今があなたの番です。台本の最後の発言に応答する形で、あなたの次のセリフだけを発言してください。"
                 f"重要：回答は常に簡潔に、{response_length_instruction}でお願いします。"
+                f"ラグにより見逃された質問があれば拾って回答してください。"
             )
 
             messages = [
@@ -90,10 +95,22 @@ def conversation_loop():
                 chat_func = ollama_chat if PROVIDER == "ollama" else lmstudio_chat
                 ai_response_text = chat_func(messages)
                 
-                new_message = {"role": "assistant", "content": ai_response_text, "name": agent_to_speak['name'], "timestamp": time.strftime('%H:%M')}
-                conversation_history.append(new_message)
-                socketio.emit('new_message', new_message)
-                print(f"{agent_to_speak['name']}: {ai_response_text}")
+                timestamp = time.strftime('%H:%M')
+                if conversation_history and conversation_history[-1].get('name') == agent_to_speak['name']:
+                    updated_content = conversation_history[-1]['content'] + f"\n(追記) {ai_response_text}"
+                    conversation_history[-1]['content'] = updated_content
+                    conversation_history[-1]['timestamp'] = timestamp
+                    socketio.emit('update_message', {
+                        'index': len(conversation_history) - 1,
+                        'content': updated_content,
+                        'timestamp': timestamp
+                    })
+                    print(f"{agent_to_speak['name']} (追記): {ai_response_text}")
+                else:
+                    new_message = {"role": "assistant", "content": ai_response_text, "name": agent_to_speak['name'], "timestamp": timestamp}
+                    conversation_history.append(new_message)
+                    socketio.emit('new_message', new_message)
+                    print(f"{agent_to_speak['name']}: {ai_response_text}")
 
             except Exception as e:
                 print(f"Error during AI call: {e}")

--- a/static/local_app.js
+++ b/static/local_app.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const socket = io();
     let userName = userNameInput.value;
+    let messageIndex = 0;
     let agents = [
         { name: "あ〜ちゃん", system: "あなたはPerfumeのあーちゃん（西脇綾香）として話す。【性格】明るくフレンドリーで場を回すタイプ。感情表現が大きく、ファンや仲間をよく褒める。ちょっと天然でユニークな言葉も作る。【人称の呼び方】自分→「あ〜ちゃん」または「私」、他メンバー→「かしゆか」「のっち」、ファン→「みんな」「あなた」。【口癖・語尾】「〜だよね〜！」「〜かなぁ？」「わかるわかる！」「うれしいね！」、オリジナル表現、笑うときは「アハハ！」。【会話スタイル】リアクション大きめでテンション高め、相手の話を広げて明るい方向に持っていく。", 
             icon: "https://www.perfume-web.jp/assets/img/profile/a-chan_2024.jpg", color: "#ff8fab", talkativeness: 1.5, response_length: 100 },
@@ -129,6 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
             </div>
         `;
+        div.dataset.index = messageIndex++;
         messagesContainer.appendChild(div);
         messagesContainer.scrollTop = messagesContainer.scrollHeight;
     }
@@ -153,7 +155,20 @@ document.addEventListener('DOMContentLoaded', () => {
         loadSettings();
     });
 
-    socket.on('history', (history) => { messagesContainer.innerHTML = ''; history.forEach(msg => addMessage(msg)); });
+    socket.on('history', (history) => {
+        messagesContainer.innerHTML = '';
+        messageIndex = 0;
+        history.forEach(msg => addMessage(msg));
+    });
     socket.on('new_message', (msg) => { addMessage(msg); });
+    socket.on('update_message', (data) => {
+        const wrapper = messagesContainer.querySelector(`.message-wrapper[data-index='${data.index}']`);
+        if (wrapper) {
+            const pre = wrapper.querySelector('.bubble pre');
+            if (pre) pre.textContent = data.content;
+            const timeEl = wrapper.querySelector('.timestamp');
+            if (timeEl && data.timestamp) timeEl.textContent = data.timestamp;
+        }
+    });
     socket.on('disconnect', () => { console.log('Disconnected from server'); });
 });


### PR DESCRIPTION
## Summary
- ensure agents mention others with @ and pick up missed questions
- append consecutive AI replies to the previous message instead of posting new ones
- track messages on the client and update content when agents add follow-ups

## Testing
- `python -m py_compile local_multi_agents_app.py`
- `node --check static/local_app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc05823b3483289977f4b00ec6b1fd