### PR TITLE
fix: remove socketio WSGI wrapping

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,1 +1,1 @@
-from local_multi_agents_app import application as app
+from local_multi_agents_app import app

--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -215,6 +215,3 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", "5000"))
     print(f"Starting server on http://localhost:{port}")
     app.run(host="0.0.0.0", port=port, debug=True)
-
-# Expose a WSGI-compatible application for platforms like Vercel
-application = app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 flask
-flask-socketio


### PR DESCRIPTION
## Summary
- remove unused SocketIO dependency and WSGI wrapper
- export plain Flask application for Vercel

## Testing
- `python -m py_compile local_multi_agents_app.py api/index.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd4870414832881f4b2e79843b48f