### PR TITLE
feat: default to Gemini backend and surface AI errors

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,1 +1,1 @@
-from local_multi_agents_app import application as app
+from local_multi_agents_app import app

--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -7,7 +7,7 @@ from flask import Flask, request, jsonify, render_template
 import threading
 
 # ===== 設定 =====
-PROVIDER = os.getenv("PROVIDER", "lmstudio")
+PROVIDER = os.getenv("PROVIDER", "gemini")
 LMSTUDIO_URL = os.getenv("LMSTUDIO_URL", "http://localhost:1234/v1/chat/completions")
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/chat")
 MODEL = os.getenv("MODEL", "gpt-4o-mini-compat")
@@ -189,6 +189,8 @@ def send_message_http():
             if not ok:
                 break
             generated.append(conversation_history[-1])
+        if not generated:
+            return jsonify({"ok": False, "error": "AI backend unavailable"}), 500
 
         return jsonify({"ok": True, "generated": generated, "history": conversation_history})
     except Exception as e:
@@ -215,6 +217,3 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", "5000"))
     print(f"Starting server on http://localhost:{port}")
     app.run(host="0.0.0.0", port=port, debug=True)
-
-# Expose a WSGI-compatible application for platforms like Vercel
-application = app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 flask
-flask-socketio


### PR DESCRIPTION
## Summary
- default provider set to Gemini API
- return an error when AI backend fails to produce responses

## Testing
- `python -m py_compile local_multi_agents_app.py api/index.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd4870414832881f4b2e79843b48f