### PR TITLE
Show delayed chat messages in JST

### DIFF
--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -1,8 +1,9 @@
 import os
 import json
 import urllib.request
-import time
 import random
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from flask import Flask, request, jsonify, render_template
 import threading
 
@@ -109,7 +110,7 @@ def generate_one_ai_turn():
     response_length_instruction = agent_to_speak.get('response_length', '3文以内')
     system_prompt = (
         agent_to_speak["system"]
-        + " 会話の流れを大切にし、他の参加者に話すときは@名前でメンションしてください。"
+        + " 会話の流れを大切にしてください。"
         + " 重要：自分自身の発言に返信する文章は書かないでください（自分宛の返信はしない）。"
     )
     user_prompt = (
@@ -137,7 +138,7 @@ def generate_one_ai_turn():
             chat_func = lmstudio_chat
         ai_response_text = chat_func(messages)
 
-        timestamp = time.strftime('%H:%M')
+        timestamp = datetime.now(ZoneInfo('Asia/Tokyo')).strftime('%H:%M')
         new_message = {"role": "assistant", "content": ai_response_text, "name": agent_to_speak['name'], "timestamp": timestamp}
         conversation_history.append(new_message)
         print(f"{agent_to_speak['name']}: {ai_response_text}")
@@ -180,7 +181,8 @@ def send_message_http():
         if not message_text:
             return jsonify({"ok": False, "error": "empty text"}), 400
 
-        new_user_msg = {"role": "user", "content": message_text, "name": user_name, "timestamp": time.strftime('%H:%M')}
+        timestamp = datetime.now(ZoneInfo('Asia/Tokyo')).strftime('%H:%M')
+        new_user_msg = {"role": "user", "content": message_text, "name": user_name, "timestamp": timestamp}
         conversation_history.append(new_user_msg)
 
         generated = []

--- a/static/local_app.js
+++ b/static/local_app.js
@@ -128,7 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const icon = !isUser ? `<div class="avatar"><img src="${agent?.icon || 'https://placehold.co/40x40/ccc/fff?text=?'}" alt="avatar"></div>` : '';
         const header = !isUser ? `<div class="message-header"><span class="agent" style="color: ${agent?.color || '#888'}">${msg.name}</span></div>` : '';
         const content = msg.content.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        const time = msg.timestamp || new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        const time = msg.timestamp || new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', timeZone: 'Asia/Tokyo' });
 
         div.innerHTML = `
             ${icon}
@@ -150,6 +150,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!text) return;
         inputEl.value = "";
         inputEl.style.height = 'auto';
+
+        const timestamp = new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', timeZone: 'Asia/Tokyo' });
+        addMessage({ role: 'user', content: text, name: userName, timestamp });
+
         try {
             const res = await fetch('/api/send_message', {
                 method: 'POST',
@@ -158,10 +162,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             const data = await res.json();
             if (data.ok) {
-                // サーバー側でユーザー発話も履歴に追加済みなので、履歴全体を再描画
-                messagesContainer.innerHTML = '';
-                messageIndex = 0;
-                (data.history || []).forEach(msg => addMessage(msg));
+                const delayMs = 600;
+                (data.generated || []).forEach((msg, idx) => {
+                    setTimeout(() => addMessage(msg), delayMs * (idx + 1));
+                });
             } else {
                 console.error('send_message error', data.error);
             }


### PR DESCRIPTION
## Summary
- Remove @ mention instruction from agent prompt
- Timestamp messages in Japan Standard Time
- Display messages one by one with a slight delay on the frontend

## Testing
- `python -m py_compile local_multi_agents_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd168bb63c832891cb6b05eddf2c7f