### PR TITLE
Add component persistence endpoints and loader

### DIFF
--- a/static/local_app.js
+++ b/static/local_app.js
@@ -184,6 +184,22 @@ document.addEventListener('DOMContentLoaded', () => {
     inputEl.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); } });
     inputEl.addEventListener('input', () => { inputEl.style.height = 'auto'; inputEl.style.height = (inputEl.scrollHeight) + 'px'; });
 
+    async function loadComponent(name) {
+        try {
+            const res = await fetch(`/api/component/${encodeURIComponent(name)}`);
+            const data = await res.json();
+            if (!data.ok) return;
+            agents = data.agents || [];
+            renderAgents();
+            await updateAgentsOnServer();
+            messagesContainer.innerHTML = '';
+            messageIndex = 0;
+            (data.history || []).forEach(msg => addMessage(msg));
+        } catch (e) {
+            console.error('loadComponent failed', e);
+        }
+    }
+
     // --- Component Upload / Save ---
     if (uploadComponentBtn) {
         uploadComponentBtn.onclick = async () => {


### PR DESCRIPTION
## Summary
- Add `/api/save_component` to persist current agents and conversation
- Add `/api/component/<name>` to retrieve saved component files
- Implement `loadComponent` on client for reloading configurations after save/upload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd2e5ad7848328b955dbe3bdc22646