### PR TITLE
Improve component portal with metadata and management actions

### DIFF
--- a/components/perfume.json
+++ b/components/perfume.json
@@ -1,5 +1,7 @@
 {
   "name": "perfume",
+  "author": "system",
+  "uploaded_at": "2025-09-07T17:00:00+09:00",
   "agents": [
     {
       "name": "あ〜ちゃん",

--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -56,7 +56,9 @@ def _load_default_agents():
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                return data.get("agents", [])
+                agents_list = data.get("agents") or []
+                if agents_list:
+                    return agents_list
             except Exception:
                 continue
     return []

--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -200,13 +200,25 @@ def get_history():
 
 @app.get("/api/list_components")
 def list_components():
-    names = set()
+    components = {}
     for directory in (READONLY_COMPONENTS_DIR, COMPONENTS_DIR):
         if os.path.isdir(directory):
             for f in os.listdir(directory):
-                if f.endswith(".json"):
-                    names.add(os.path.splitext(f)[0])
-    return jsonify(sorted(names))
+                if not f.endswith(".json"):
+                    continue
+                path = os.path.join(directory, f)
+                try:
+                    with open(path, "r", encoding="utf-8") as file:
+                        data = json.load(file)
+                    name = data.get("name", os.path.splitext(f)[0])
+                    components[name] = {
+                        "name": name,
+                        "author": data.get("author", ""),
+                        "uploaded_at": data.get("uploaded_at", ""),
+                    }
+                except Exception:
+                    continue
+    return jsonify(sorted(components.values(), key=lambda x: x["name"]))
 
 @app.get("/api/get_component")
 def get_component():
@@ -227,6 +239,7 @@ def upload_component():
     try:
         data = request.get_json(force=True) or {}
         name = (data.get("name") or "").strip()
+        author = (data.get("author") or "").strip()
         agents_data = data.get("agents")
         if not name or not isinstance(agents_data, list):
             return jsonify({"ok": False, "error": "invalid data"}), 400
@@ -234,9 +247,32 @@ def upload_component():
         if not safe_name:
             return jsonify({"ok": False, "error": "invalid name"}), 400
         path = os.path.join(COMPONENTS_DIR, f"{safe_name}.json")
+        payload = {
+            "name": safe_name,
+            "author": author,
+            "uploaded_at": datetime.now(ZoneInfo('Asia/Tokyo')).isoformat(),
+            "agents": agents_data,
+        }
         with open(path, "w", encoding="utf-8") as f:
-            json.dump({"name": safe_name, "agents": agents_data}, f, ensure_ascii=False, indent=2)
+            json.dump(payload, f, ensure_ascii=False, indent=2)
         return jsonify({"ok": True, "name": safe_name})
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)}), 500
+
+
+@app.post("/api/delete_component")
+def delete_component():
+    try:
+        data = request.get_json(force=True) or {}
+        name = (data.get("name") or "").strip()
+        safe_name = "".join(c for c in name if c.isalnum() or c in ("-", "_")).strip()
+        if not safe_name:
+            return jsonify({"ok": False, "error": "invalid name"}), 400
+        path = os.path.join(COMPONENTS_DIR, f"{safe_name}.json")
+        if os.path.exists(path):
+            os.remove(path)
+            return jsonify({"ok": True})
+        return jsonify({"ok": False, "error": "not found"}), 404
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
 

--- a/static/components_portal.css
+++ b/static/components_portal.css
@@ -1,0 +1,53 @@
+body {
+  background: var(--page-bg);
+  color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.portal-container {
+  max-width: 800px;
+  margin: 40px auto;
+  background: var(--bg-color);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.portal-container h1 {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+th {
+  background: var(--accent-color);
+  color: var(--header-text);
+  text-align: left;
+}
+
+td.actions {
+  white-space: nowrap;
+}
+
+button.action {
+  margin-right: 6px;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: var(--accent-color);
+  color: var(--header-text);
+}
+
+button.action.delete {
+  background: #e74c3c;
+}

--- a/static/components_portal.js
+++ b/static/components_portal.js
@@ -4,15 +4,32 @@ document.addEventListener('DOMContentLoaded', () => {
   async function loadList() {
     try {
       const res = await fetch('/api/list_components');
-      const names = await res.json();
+      const comps = await res.json();
       listEl.innerHTML = '';
-      names.forEach(name => {
-        const li = document.createElement('li');
-        const btn = document.createElement('button');
-        btn.textContent = 'インストール';
-        btn.onclick = async () => {
+      comps.forEach(comp => {
+        const tr = document.createElement('tr');
+
+        const nameTd = document.createElement('td');
+        nameTd.textContent = comp.name;
+        tr.appendChild(nameTd);
+
+        const authorTd = document.createElement('td');
+        authorTd.textContent = comp.author || '';
+        tr.appendChild(authorTd);
+
+        const dateTd = document.createElement('td');
+        dateTd.textContent = comp.uploaded_at || '';
+        tr.appendChild(dateTd);
+
+        const actionsTd = document.createElement('td');
+        actionsTd.className = 'actions';
+
+        const installBtn = document.createElement('button');
+        installBtn.textContent = 'インストール';
+        installBtn.className = 'action';
+        installBtn.onclick = async () => {
           try {
-            const r = await fetch(`/api/get_component?name=${encodeURIComponent(name)}`);
+            const r = await fetch(`/api/get_component?name=${encodeURIComponent(comp.name)}`);
             const data = await r.json();
             if (data.agents) {
               await fetch('/api/update_agents', {
@@ -26,12 +43,54 @@ document.addEventListener('DOMContentLoaded', () => {
             console.warn('install failed', e);
           }
         };
-        li.textContent = name + ' ';
-        li.appendChild(btn);
-        listEl.appendChild(li);
+        actionsTd.appendChild(installBtn);
+
+        const editBtn = document.createElement('button');
+        editBtn.textContent = '編集';
+        editBtn.className = 'action';
+        editBtn.onclick = async () => {
+          try {
+            const r = await fetch(`/api/get_component?name=${encodeURIComponent(comp.name)}`);
+            const data = await r.json();
+            const edited = prompt('コンポーネントJSONを編集', JSON.stringify(data, null, 2));
+            if (edited) {
+              const newData = JSON.parse(edited);
+              await fetch('/api/upload_component', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(newData)
+              });
+              loadList();
+            }
+          } catch (e) {
+            console.warn('edit failed', e);
+          }
+        };
+        actionsTd.appendChild(editBtn);
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.textContent = '削除';
+        deleteBtn.className = 'action delete';
+        deleteBtn.onclick = async () => {
+          if (!confirm(`${comp.name}を削除しますか？`)) return;
+          try {
+            await fetch('/api/delete_component', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: comp.name })
+            });
+            loadList();
+          } catch (e) {
+            console.warn('delete failed', e);
+          }
+        };
+        actionsTd.appendChild(deleteBtn);
+
+        tr.appendChild(actionsTd);
+        listEl.appendChild(tr);
       });
     } catch (e) {
-      listEl.innerHTML = '<li>読み込み失敗</li>';
+      listEl.innerHTML = '<tr><td colspan="4">読み込み失敗</td></tr>';
     }
   }
 

--- a/static/local_app.js
+++ b/static/local_app.js
@@ -112,15 +112,15 @@ document.addEventListener('DOMContentLoaded', () => {
     async function loadComponentList() {
         try {
             const res = await fetch('/api/list_components');
-            const names = await res.json();
+            const comps = await res.json();
             componentSelect.innerHTML = '';
-            names.forEach(name => {
+            comps.forEach(comp => {
                 const opt = document.createElement('option');
-                opt.value = name;
-                opt.textContent = name;
+                opt.value = comp.name;
+                opt.textContent = comp.name;
                 componentSelect.appendChild(opt);
             });
-            return names;
+            return comps.map(c => c.name);
         } catch (e) {
             console.warn('list_components failed', e);
             return [];

--- a/templates/components_portal.html
+++ b/templates/components_portal.html
@@ -4,10 +4,23 @@
   <meta charset="utf-8">
   <title>コンポーネントポータル</title>
   <link rel="stylesheet" href="/static/local_styles.css">
+  <link rel="stylesheet" href="/static/components_portal.css">
 </head>
 <body>
-  <h1>コンポーネントポータル</h1>
-  <ul id="component-list"></ul>
+  <div class="portal-container">
+    <h1>コンポーネントポータル</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>名前</th>
+          <th>作者</th>
+          <th>アップ日時</th>
+          <th>操作</th>
+        </tr>
+      </thead>
+      <tbody id="component-list"></tbody>
+    </table>
+  </div>
   <script src="/static/components_portal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Style component portal with dedicated CSS and table layout
- Show author and upload time for each component and allow install, edit, and delete
- Store component metadata server-side and expose API endpoints for listing and deleting

## Testing
- `python -m py_compile local_multi_agents_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd39f940e48328b14aeb72a2c3170f