### PR TITLE
feat: add configurable reply count and delay

### DIFF
--- a/templates/local_index.html
+++ b/templates/local_index.html
@@ -50,6 +50,14 @@
             <label for="bg-image-input">背景画像 URL</label>
             <input type="url" id="bg-image-input" placeholder="https://...">
           </div>
+          <div class="setting-item">
+            <label for="reply-count-range">返信数: <span id="reply-count-value">5</span></label>
+            <input type="range" id="reply-count-range" min="1" max="10" value="5">
+          </div>
+          <div class="setting-item">
+            <label for="reply-interval-range">返信間隔(秒): <span id="reply-interval-value">1</span></label>
+            <input type="range" id="reply-interval-range" min="0.5" max="5" step="0.5" value="1">
+          </div>
         </section>
         <hr class="divider">
         <section class="settings-section">


### PR DESCRIPTION
## Summary
- add settings sliders for reply count and reply interval
- use slider values to control turns and schedule responses based on length

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile local_multi_agents_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd4cdec65c83288d094dec37c0ec95