### PR TITLE
Serve favicon to avoid 404 errors

### DIFF
--- a/local_multi_agents_app.py
+++ b/local_multi_agents_app.py
@@ -4,7 +4,7 @@ import urllib.request
 import random
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from flask import Flask, request, jsonify, render_template
+from flask import Flask, request, jsonify, render_template, Response
 import threading
 
 # ===== 設定 =====
@@ -45,6 +45,16 @@ app = Flask(
     static_folder=os.path.join(BASE_DIR, "static"),
 )
 app.config['SECRET_KEY'] = 'secret!'
+
+FAVICON_SVG = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' fill='#555'/></svg>"
+
+
+@app.route('/favicon.ico')
+@app.route('/favicon.png')
+@app.route('/favicon.svg')
+def favicon():
+    """Serve a tiny SVG favicon to avoid unnecessary 404s."""
+    return Response(FAVICON_SVG, mimetype='image/svg+xml')
 
 # ===== 会話状態 =====
 conversation_history = []

--- a/templates/components_portal.html
+++ b/templates/components_portal.html
@@ -1,12 +1,13 @@
 <!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="utf-8">
-  <title>コンポーネントポータル</title>
-  <link rel="stylesheet" href="/static/local_styles.css">
-  <link rel="stylesheet" href="/static/components_portal.css">
-</head>
-<body>
+  <head>
+    <meta charset="utf-8">
+    <title>コンポーネントポータル</title>
+    <link rel="stylesheet" href="/static/local_styles.css">
+    <link rel="stylesheet" href="/static/components_portal.css">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  </head>
+  <body>
   <div class="portal-container">
     <h1>コンポーネントポータル</h1>
     <table>

--- a/templates/local_index.html
+++ b/templates/local_index.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Local Multi-Agent Chat</title>
-  <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
-  <link rel="stylesheet" href="/static/local_styles.css">
-</head>
-<body>
+    <title>Local Multi-Agent Chat</title>
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+    <link rel="stylesheet" href="/static/local_styles.css">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  </head>
+  <body>
   <div class="app-container">
     <header class="app-header">
       <h1>Multi-Agent Chat</h1>


### PR DESCRIPTION
## Summary
- serve a tiny inline SVG favicon to avoid missing-file requests without committing binaries
- reference the SVG favicon in HTML templates

## Testing
- `python -m py_compile local_multi_agents_app.py && echo py_compile_success`
- `PORT=5001 nohup python local_multi_agents_app.py >/tmp/server.log 2>&1 &` (in a separate session)
- `curl -I http://localhost:5001/favicon.svg`
- `curl -I http://localhost:5001/favicon.ico`


------
https://chatgpt.com/codex/tasks/task_e_68be574a5ac483289b1e1b3d0c0f46dd